### PR TITLE
Fix internal references and include Godeps

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,0 +1,1 @@
+github.com/VividCortex/goprotobuf 7a8229e9f122ffb2c45fb42a9c323df463f48cbc

--- a/groupcache.go
+++ b/groupcache.go
@@ -31,9 +31,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	pb "github.com/golang/groupcache/groupcachepb"
-	"github.com/golang/groupcache/lru"
-	"github.com/golang/groupcache/singleflight"
+	pb "github.com/VividCortex/groupcache/groupcachepb"
+	"github.com/VividCortex/groupcache/lru"
+	"github.com/VividCortex/groupcache/singleflight"
 )
 
 // A Getter loads data for a key.

--- a/groupcache_test.go
+++ b/groupcache_test.go
@@ -28,10 +28,10 @@ import (
 	"testing"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/VividCortex/goprotobuf/proto"
 
-	pb "github.com/golang/groupcache/groupcachepb"
-	testpb "github.com/golang/groupcache/testpb"
+	pb "github.com/VividCortex/groupcache/groupcachepb"
+	testpb "github.com/VividCortex/groupcache/testpb"
 )
 
 var (

--- a/groupcachepb/groupcache.pb.go
+++ b/groupcachepb/groupcache.pb.go
@@ -4,7 +4,7 @@
 
 package groupcachepb
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/VividCortex/goprotobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/http.go
+++ b/http.go
@@ -24,9 +24,9 @@ import (
 	"strings"
 	"sync"
 
-	"code.google.com/p/goprotobuf/proto"
-	"github.com/golang/groupcache/consistenthash"
-	pb "github.com/golang/groupcache/groupcachepb"
+	"github.com/VividCortex/goprotobuf/proto"
+	"github.com/VividCortex/groupcache/consistenthash"
+	pb "github.com/VividCortex/groupcache/groupcachepb"
 )
 
 // TODO: make this configurable?

--- a/peers.go
+++ b/peers.go
@@ -19,7 +19,7 @@ limitations under the License.
 package groupcache
 
 import (
-	pb "github.com/golang/groupcache/groupcachepb"
+	pb "github.com/VividCortex/groupcache/groupcachepb"
 )
 
 // Context is an opaque value passed through calls to the

--- a/sinks.go
+++ b/sinks.go
@@ -19,7 +19,7 @@ package groupcache
 import (
 	"errors"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/VividCortex/goprotobuf/proto"
 )
 
 // A Sink receives data from a Get call.

--- a/testpb/test.pb.go
+++ b/testpb/test.pb.go
@@ -4,7 +4,7 @@
 
 package testpb
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/VividCortex/goprotobuf/proto"
 import json "encoding/json"
 import math "math"
 


### PR DESCRIPTION
Internal references were pointing to the original repository at github.com/golang. Those were changed to point to this forked copy. Also, references to code.google.com/p/goprotobuf were replaced by our forked copy at https://github.com/VividCortex/goprotobuf.

Closes #1.
